### PR TITLE
fix(router): include ctx-shared in package files

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -19,6 +19,7 @@
     "types",
     "_ctx.*",
     "_ctx-html.js",
+    "_ctx-shared.js",
     "_error.js",
     "app.plugin.js",
     "babel.js",


### PR DESCRIPTION
# Why

Fixes the failure documented in #27740 wherein typed route generation failed to find an import called `ctx-shared` in the Expo Router canary package.

# How

Includes the `ctx-shared.js` file used by typed route generation in the expo-router package files by adding it to the explicit list of included files in `package.json`.

# Test Plan

To test I started with my [minimal reproduction](https://github.com/chriszs/test-expo-app/pull/3) (in which `npm start` fails), downloaded [ctx-shared.js](https://github.com/chriszs/expo/blob/main/packages/expo-router/_ctx-shared.js), moved it into `node_modules/expo-router/` and then ran `npm start` again (successfully).